### PR TITLE
Rename symbols to allow Apple App Store uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ third_party/hdrvdp-2.2.2.zip.tmp
 tools/benchmark/metrics/plots
 tools/benchmark/metrics/results.csv
 tools/conformance/__pycache__
+
+# Editor configuration
+*.code-workspace
+
+# macOS Finder state files
+.DS_Store
+
+# Clion IDE
+.idea/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,59 @@ check_cxx_source_compiles(
   JPEGXL_EMSCRIPTEN
 )
 
+if(APPLE)
+  message(STATUS "Configuring libjxl for Apple platforms - prefixing symbols to avoid App Store private API collisions")
+
+  # Create a list of all JXL symbols that need prefixing
+  set(JXL_SYMBOLS_TO_PREFIX
+          # Decoder symbols
+          JxlDecoderCreate
+          JxlDecoderDestroy
+          JxlDecoderReset
+          JxlDecoderRewind
+          JxlDecoderSetInput
+          JxlDecoderReleaseInput
+          JxlDecoderProcessInput
+          JxlDecoderSubscribeEvents
+          JxlDecoderSetImageOutCallback
+          JxlDecoderSetImageOutBuffer
+          JxlDecoderImageOutBufferSize
+          JxlDecoderGetBasicInfo
+          JxlDecoderGetFrameHeader
+          JxlDecoderGetColorAsEncodedProfile
+          JxlDecoderSetPreferredColorProfile
+          JxlDecoderSetProgressiveDetail
+          JxlDecoderFlushImage
+
+          # Encoder symbols
+          JxlEncoderCreate
+          JxlEncoderDestroy
+          JxlEncoderReset
+          JxlEncoderSetFrameHeader
+          JxlEncoderAddImageFrame
+          JxlEncoderCloseInput
+          JxlEncoderProcessOutput
+
+          # Thread parallel runner
+          JxlThreadParallelRunner
+          JxlThreadParallelRunnerCreate
+          JxlThreadParallelRunnerDestroy
+
+          # Add more as needed...
+  )
+
+  # Generate compile definitions to rename each symbol
+  foreach(symbol ${JXL_SYMBOLS_TO_PREFIX})
+    list(APPEND JXL_APPLE_DEFINITIONS "-D${symbol}=SDL_${symbol}")
+  endforeach()
+
+  # Apply to all targets
+  add_compile_options(${JXL_APPLE_DEFINITIONS})
+
+  # Also need to handle any pkg-config or cmake config files
+  set(JXL_PUBLIC_SYMBOLS_PREFIX "SDL_")
+endif()
+
 message(STATUS "CMAKE_SYSTEM_PROCESSOR is ${CMAKE_SYSTEM_PROCESSOR}")
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-fsanitize=fuzzer-no-link" CXX_FUZZERS_SUPPORTED)


### PR DESCRIPTION
### Description

- Apple's App Store validation rejects binaries that reference certain symbol names (like JxlDecoder*) as they conflict with private APIs.

- This patch renames all public libjxl symbols with an SDL_ prefix when building for Apple platforms to avoid these conflicts.

<img width="1442" height="620" alt="Screenshot 2025-11-08 at 6 04 48 PM" src="https://github.com/user-attachments/assets/13ddb808-ed61-47b1-b21d-91c9c774827d" />
